### PR TITLE
Check error returned by app.Run()

### DIFF
--- a/flint.go
+++ b/flint.go
@@ -59,5 +59,8 @@ func main() {
 		}
 	}
 
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This will print a proper error message when invalid args are passed to flint, instead of ignoring them silently.

@pengwynn Personally, I'd write error messages to stderr, e.g. using `log.Fatal()`, but since you do not write lint errors to stderr either, I didn't bother doing it.
