### PR TITLE
added output coloring using fatih/color module

### DIFF
--- a/flint.go
+++ b/flint.go
@@ -20,7 +20,7 @@ func main() {
 		cli.BoolFlag{"skip-bootstrap", "skip check for bootstrap script"},
 		cli.BoolFlag{"skip-test", "skip check for test script"},
 		cli.BoolFlag{"skip-scripts", "skip check for all scripts"},
-		cli.BoolFlag{"skip-output-color", "skip coloring the terminal output"},
+		cli.BoolFlag{"no-color", "skip coloring the terminal output"},
 	}
 	app.Action = func(c *cli.Context) {
 		path, _ := os.Getwd()
@@ -49,7 +49,7 @@ func main() {
 
 		if len(linter.Errors) > 0 {
 			for _, element := range linter.Errors {
-				if !c.Bool("skip-output-color") { // if not skipping output color
+				if !c.Bool("no-color") { // if not skipping output color
 					if element.Level == 0 { // if [FIXME]
 						color.White(element.Message)
 					} else { // if [ERROR]
@@ -61,7 +61,7 @@ func main() {
 			}
 			level := linter.Severity()
 			if level > 0 {
-				if !c.Bool("skip-output-color") {
+				if !c.Bool("no-color") {
 					color.Red("[CRITICAL] Some critical problems found. Please fix right away!")
 				} else {
 					fmt.Println("[CRITICAL] Some critical problems found. Please fix right away!")
@@ -69,7 +69,7 @@ func main() {
 			}
 			os.Exit(level)
 		} else {
-			if !c.Bool("skip-output-color") {
+			if !c.Bool("no-color") {
 				color.Green("[OK] All is well!")
 			} else {
 				fmt.Println("[OK] All is well!")


### PR DESCRIPTION
I think this resolves #8 through enabling optional color support for the output of flint using https://github.com/fatih/color. This is my first time doing a pull request (and my first open source contribution haha), so please let me know if I need to make any changes!
