### PR TITLE
Build fixture path correctly on Windows

### DIFF
--- a/flint/github_fetcher_test.go
+++ b/flint/github_fetcher_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -214,7 +214,7 @@ func testMethod(t *testing.T, r *http.Request, want string) {
 
 func loadFixture(f string) string {
 	pwd, _ := os.Getwd()
-	p := path.Join(pwd, "..", "fixtures", f)
+	p := filepath.Join(pwd, "..", "fixtures", f)
 	c, _ := ioutil.ReadFile(p)
 	return string(c)
 }


### PR DESCRIPTION
This swaps `path` for `filepath` since the former is not OS-independent.

As discovered by @dhs252 in https://github.com/octokit/go-octokit/pull/76