### PR TITLE
Don't color output on windows

### DIFF
--- a/flint/app.go
+++ b/flint/app.go
@@ -5,6 +5,7 @@ import (
 
 	"fmt"
 	"os"
+	"runtime"
 )
 
 func NewApp() *cli.App {
@@ -52,7 +53,12 @@ var run = func(c *cli.Context) {
 		return
 	}
 	if summary != nil {
-		summary.Print(os.Stderr, !c.Bool("no-color"))
+		color := !c.Bool("no-color")
+		// Windows doesn't support colors
+		if runtime.GOOS == "windows" {
+			color = false
+		}
+		summary.Print(os.Stderr, color)
 		os.Exit(summary.Severity())
 	}
 }


### PR DESCRIPTION
Or otherwise you'll get output like this:

```
←[31m[ERROR] CONTRIBUTING guide not found
←[0m[INFO] Add a guide for potential contributors. http://git.io/z-TiGg
←[33m[WARNING] Bootstrap script not found
←[0m[INFO] A bootstrap script makes setup a snap. http://bit.ly/JZjVL6
←[33m[WARNING] Test script not found
←[0m[INFO] Make it easy to run the test suite regardless of project type. http://bit.ly/JZjVL6
←[31m[CRITICAL] Some critical problems found.
←[0m
```