### PR TITLE
Fix compile error "too few values in struct initializer"

### DIFF
--- a/flint/app.go
+++ b/flint/app.go
@@ -14,13 +14,13 @@ func NewApp() *cli.App {
 	app.Usage = "Check a project for common sources of contributor friction"
 	app.Version = "0.0.4"
 	app.Flags = []cli.Flag{
-		cli.BoolFlag{"skip-readme", "skip check for README", ""},
-		cli.BoolFlag{"skip-contributing", "skip check for contributing guide", ""},
-		cli.BoolFlag{"skip-license", "skip check for license", ""},
-		cli.BoolFlag{"skip-bootstrap", "skip check for bootstrap script", ""},
-		cli.BoolFlag{"skip-test-script", "skip check for test script", ""},
-		cli.BoolFlag{"skip-scripts", "skip check for all scripts", ""},
-		cli.BoolFlag{"no-color", "skip coloring the terminal output", ""},
+		cli.BoolFlag{"skip-readme", "skip check for README", "", nil},
+		cli.BoolFlag{"skip-contributing", "skip check for contributing guide", "", nil},
+		cli.BoolFlag{"skip-license", "skip check for license", "", nil},
+		cli.BoolFlag{"skip-bootstrap", "skip check for bootstrap script", "", nil},
+		cli.BoolFlag{"skip-test-script", "skip check for test script", "", nil},
+		cli.BoolFlag{"skip-scripts", "skip check for all scripts", "", nil},
+		cli.BoolFlag{"no-color", "skip coloring the terminal output", "", nil},
 		cli.StringFlag{
 			Name:  "github, g",
 			Value: "",


### PR DESCRIPTION
I was unable to do `go get github.com/pengwynn/flint` on Debian Unstable with Go 1.5.1 (Debian package `golang-go` at version 2:1.5.1-4):

```
→ go get github.com/pengwynn/flint
# github.com/pengwynn/flint/flint
../.go/src/github.com/pengwynn/flint/flint/app.go:17: too few values in struct initializer
../.go/src/github.com/pengwynn/flint/flint/app.go:18: too few values in struct initializer
../.go/src/github.com/pengwynn/flint/flint/app.go:19: too few values in struct initializer
../.go/src/github.com/pengwynn/flint/flint/app.go:20: too few values in struct initializer
../.go/src/github.com/pengwynn/flint/flint/app.go:21: too few values in struct initializer
../.go/src/github.com/pengwynn/flint/flint/app.go:22: too few values in struct initializer
../.go/src/github.com/pengwynn/flint/flint/app.go:23: too few values in struct initializer
```

This patch fixes the issue.

I though have no idea what the fourth missing parameter means, so I'm not sure if `nil` is really the right value for that parameter. But `flint` seems to work afterwards, so it can't be that wrong. ;-)