### PR TITLE
Fix flags and color

### DIFF
--- a/flint/app.go
+++ b/flint/app.go
@@ -14,13 +14,13 @@ func NewApp() *cli.App {
 	app.Usage = "Check a project for common sources of contributor friction"
 	app.Version = "0.0.4"
 	app.Flags = []cli.Flag{
-		cli.BoolFlag{"skip-readme", "skip check for README", ""},
-		cli.BoolFlag{"skip-contributing", "skip check for contributing guide", ""},
-		cli.BoolFlag{"skip-license", "skip check for license", ""},
-		cli.BoolFlag{"skip-bootstrap", "skip check for bootstrap script", ""},
-		cli.BoolFlag{"skip-test-script", "skip check for test script", ""},
-		cli.BoolFlag{"skip-scripts", "skip check for all scripts", ""},
-		cli.BoolFlag{"no-color", "skip coloring the terminal output", ""},
+		cli.BoolFlag{"skip-readme", "skip check for README", "", nil},
+		cli.BoolFlag{"skip-contributing", "skip check for contributing guide", "", nil},
+		cli.BoolFlag{"skip-license", "skip check for license", "", nil},
+		cli.BoolFlag{"skip-bootstrap", "skip check for bootstrap script", "", nil},
+		cli.BoolFlag{"skip-test-script", "skip check for test script", "", nil},
+		cli.BoolFlag{"skip-scripts", "skip check for all scripts", "", nil},
+		cli.BoolFlag{"no-color", "skip coloring the terminal output", "", nil},
 		cli.StringFlag{
 			Name:  "github, g",
 			Value: "",

--- a/flint/summary.go
+++ b/flint/summary.go
@@ -27,16 +27,13 @@ func (list *Summary) Severity() int {
 
 func (l *Summary) Print(out io.Writer, colored bool) {
 	info := func(a ...interface{}) { fmt.Fprintln(out, a...) }
-	warn := info
-	fail := info
-	success := info
+	warn := color.New(color.FgYellow).PrintlnFunc()
+	fail := color.New(color.FgRed).PrintlnFunc()
+	success := color.New(color.FgGreen).PrintlnFunc()
 
 	color.Output = out
-	if colored {
-		warn = color.New(color.FgYellow).PrintlnFunc()
-		fail = color.New(color.FgRed).PrintlnFunc()
-		success = color.New(color.FgGreen).PrintlnFunc()
-	}
+	color.NoColor = !colored
+
 	if len(l.Errors) == 0 {
 		message := "[OK] All is well!"
 		success(message)


### PR DESCRIPTION
Builds atop of https://github.com/pengwynn/flint/pull/34 and fixes a few additional failing tests due to a change in the default behavior of the `color` package. https://github.com/fatih/color/commit/9d282f22ae3a57f7b0a1f670f9a1ccc64c0f8cd2

/cc @xtaran

Closes #34.