### PR TITLE
Recognize GNU's common COPYING file as LICENSE

### DIFF
--- a/flint/local_project.go
+++ b/flint/local_project.go
@@ -23,7 +23,7 @@ func (l *LocalProject) CheckContributing() bool {
 }
 
 func (l *LocalProject) CheckLicense() bool {
-	return l.searchPath("LICENSE*")
+	return l.searchPath("LICENSE*") || l.searchPath("COPYING*")
 }
 
 func (l *LocalProject) CheckBootstrap() bool {

--- a/flint/local_project_test.go
+++ b/flint/local_project_test.go
@@ -69,10 +69,12 @@ func TestLocalProjectFindsContributing(t *testing.T) {
 var licenseTests = []scenarios{
 	{"", false},
 	{"LICENSE", true},
+	{"COPYING", true},
 	{"LICENSE.md", true},
 	{"LICENSE.rst", true},
 	{"docs/LICENSE.rst", false},
 	{"docs/LICENSE.md", false},
+	{"docs/COPYING", false},
 }
 
 func TestLocalProjectFindsLicense(t *testing.T) {

--- a/flint/remote_project.go
+++ b/flint/remote_project.go
@@ -65,7 +65,7 @@ func (l *RemoteProject) CheckContributing() bool {
 }
 
 func (l *RemoteProject) CheckLicense() bool {
-	return l.searchPath(regexp.MustCompile(`LICENSE`))
+	return l.searchPath(regexp.MustCompile(`LICENSE|COPYING`))
 }
 
 func (l *RemoteProject) CheckBootstrap() bool {

--- a/flint/remote_project_test.go
+++ b/flint/remote_project_test.go
@@ -70,6 +70,14 @@ func TestRemoteProjectCheckLicense(t *testing.T) {
 	assert.False(t, project.CheckLicense())
 }
 
+func TestRemoteProjectCheckCopying(t *testing.T) {
+	project := &RemoteProject{FullName: "projects/copying"}
+	fetcher := &FakeProjectFetcher{}
+	err := project.Fetch(fetcher)
+	assert.Nil(t, err)
+	assert.True(t, project.CheckLicense())
+}
+
 func TestRemoteProjectCheckBootstrap(t *testing.T) {
 	project := &RemoteProject{FullName: "octokit/octokit.rb"}
 	fetcher := &FakeProjectFetcher{}
@@ -144,6 +152,14 @@ func (f *FakeProjectFetcher) FetchTree(nwo string) (paths []string, err error) {
 		}
 	case "projects/no-files":
 		paths = []string{}
+	case "projects/copying":
+		paths = []string{
+			"COPYING",
+			"contributing",
+			"readme",
+			"script/bootstrap",
+			"script/test",
+		}
 	}
 	return paths, nil
 }


### PR DESCRIPTION
Closes #35 by treating a `COPYING` file the same as a project license since that's a common GNU convention.

/cc @xtaran 