### PR TITLE
[ci skip] readme: use code blocks without syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Check your project for common sources of contributor friction.
 If you've got Go installed, you can install flint with Go's command line
 interface:
 
-```
-go get github.com/pengwynn/flint
-```
+    go get github.com/pengwynn/flint
 
 You can test your installation by running `flint --version` from any folder.
 
@@ -22,21 +20,19 @@ Run `flint` from your project root to check for some common ways to improve the
 experience for potential contributors. Here's the output for a blank folder to
 show the full gamut of suggestions:
 
-```sh
-~/projects/dream
-❯ flint
-[ERROR] README not found
-[INFO] Every project begins with a README. http://bit.ly/1dqUYQF
-[ERROR] CONTRIBUTING guide not found
-[INFO] Add a guide for potential contributors. http://git.io/z-TiGg
-[ERROR] LICENSE not found
-[INFO] Add a license to protect yourself and your users. http://choosealicense.com/
-[WARNING] Bootstrap script not found
-[INFO] A bootstrap script makes setup a snap. http://bit.ly/JZjVL6
-[WARNING] Test script not found
-[INFO] Make it easy to run the test suite regardless of project type. http://bit.ly/JZjVL6
-[CRITICAL] Some critical problems found.
-```
+    ~/projects/dream
+    ❯ flint
+    [ERROR] README not found
+    [INFO] Every project begins with a README. http://bit.ly/1dqUYQF
+    [ERROR] CONTRIBUTING guide not found
+    [INFO] Add a guide for potential contributors. http://git.io/z-TiGg
+    [ERROR] LICENSE not found
+    [INFO] Add a license to protect yourself and your users. http://choosealicense.com/
+    [WARNING] Bootstrap script not found
+    [INFO] A bootstrap script makes setup a snap. http://bit.ly/JZjVL6
+    [WARNING] Test script not found
+    [INFO] Make it easy to run the test suite regardless of project type. http://bit.ly/JZjVL6
+    [CRITICAL] Some critical problems found.
 
 You can also run this in older projects which were created by lazy you, or by
 younger, less wise you.
@@ -44,43 +40,40 @@ younger, less wise you.
 If you want to check a remote GitHub repository, you can now do so without
 cloning:
 
-```sh
-❯ flint --github pengwynn/dotfiles
-[ERROR] CONTRIBUTING guide not found
-[INFO] Add a guide for potential contributors. http://git.io/z-TiGg
-[WARNING] Test script not found
-[INFO] Make it easy to run the test suite regardless of project type. http://bit.ly/JZjVL6
-[CRITICAL] Some critical problems found.
-```
+    ❯ flint --github pengwynn/dotfiles
+    [ERROR] CONTRIBUTING guide not found
+    [INFO] Add a guide for potential contributors. http://git.io/z-TiGg
+    [WARNING] Test script not found
+    [INFO] Make it easy to run the test suite regardless of project type. http://bit.ly/JZjVL6
+    [CRITICAL] Some critical problems found.
+
 Passing the `-h` flag will show full usage options:
 
-```
-❯ flint -h
-NAME:
-   flint - Check a project for common sources of contributor friction
-
-USAGE:
-   flint [global options] command [command options] [arguments...]
-
-VERSION:
-   0.0.4
-
-COMMANDS:
-   help, h      Shows a list of commands or help for one command
-
-GLOBAL OPTIONS:
-   --skip-readme        skip check for README
-   --skip-contributing  skip check for contributing guide
-   --skip-license       skip check for license
-   --skip-bootstrap     skip check for bootstrap script
-   --skip-test-script   skip check for test script
-   --skip-scripts       skip check for all scripts
-   --no-color           skip coloring the terminal output
-   --github, -g         GitHub repository as owner/repo
-   --token, -t          GitHub API access token [$FLINT_TOKEN]
-   --help, -h           show help
-   --version, -v        print the version
-```
+    ❯ flint -h
+    NAME:
+       flint - Check a project for common sources of contributor friction
+    
+    USAGE:
+       flint [global options] command [command options] [arguments...]
+    
+    VERSION:
+       0.0.4
+    
+    COMMANDS:
+       help, h      Shows a list of commands or help for one command
+    
+    GLOBAL OPTIONS:
+       --skip-readme        skip check for README
+       --skip-contributing  skip check for contributing guide
+       --skip-license       skip check for license
+       --skip-bootstrap     skip check for bootstrap script
+       --skip-test-script   skip check for test script
+       --skip-scripts       skip check for all scripts
+       --no-color           skip coloring the terminal output
+       --github, -g         GitHub repository as owner/repo
+       --token, -t          GitHub API access token [$FLINT_TOKEN]
+       --help, -h           show help
+       --version, -v        print the version
 
 ### Philosophy
 


### PR DESCRIPTION
Now the words `test` and `type` are no longer highlighted.
I know you used the `sh` type code block on purpose,
but I think the resulting syntax highlighting had no advantage.